### PR TITLE
Make heartbeats real events

### DIFF
--- a/lib/pubsubstub/stream_action.rb
+++ b/lib/pubsubstub/stream_action.rb
@@ -33,7 +33,8 @@ module Pubsubstub
       @heartbeat = Thread.new do
         loop do
           sleep Pubsubstub.heartbeat_frequency
-          @connections.each { |connection| connection << "\n" }
+          event = Event.new('ping', name: 'heartbeat').to_message
+          @connections.each { |connection| connection << event }
         end
       end
     end


### PR DESCRIPTION
This will make it easier to monitor from JavaScript if the connection
is still alive.

Browsers implementations of EventSource may or may not reconnect
depending on the type of error. With this heartbeat we can monitor
client when the last event was recived, and reinitialize the
EventSource manually.
