### PR TITLE
Allow configuring redis_url

### DIFF
--- a/lib/pubsubstub.rb
+++ b/lib/pubsubstub.rb
@@ -11,3 +11,10 @@ require "pubsubstub/stream_action"
 require "pubsubstub/publish_action"
 require "pubsubstub/application"
 
+module Pubsubstub
+  class << self
+    attr_accessor :heartbeat_frequency, :redis_url
+  end
+  self.heartbeat_frequency = 15
+end
+

--- a/lib/pubsubstub/application.rb
+++ b/lib/pubsubstub/application.rb
@@ -1,11 +1,5 @@
 module Pubsubstub
-  class << self
-    attr_accessor :heartbeat_frequency
-  end
-  self.heartbeat_frequency = 15
-
   class Application < Sinatra::Base
-
     use PublishAction
     use StreamAction
   end

--- a/lib/pubsubstub/redis_pub_sub.rb
+++ b/lib/pubsubstub/redis_pub_sub.rb
@@ -66,7 +66,7 @@ module Pubsubstub
       end
 
       def redis_url
-        ENV['REDIS_URL'] || "redis://localhost:6379"
+        Pubsubstub.redis_url || ENV['REDIS_URL'] || "redis://localhost:6379/0"
       end
     end
   end

--- a/spec/redis_pub_sub_spec.rb
+++ b/spec/redis_pub_sub_spec.rb
@@ -34,6 +34,21 @@ describe Pubsubstub::RedisPubSub do
         expect(subject.blocking_redis.zcard("test.scrollback")).to eq(count - 1)
       end
     end
+
+    describe "#redis_url" do
+      it "uses the fallback url fallback chain" do
+        Pubsubstub.redis_url = "redis://localhost:6379/1"
+        expect(Pubsubstub::RedisPubSub.redis_url).to eq("redis://localhost:6379/1")
+
+        Pubsubstub.redis_url = nil
+        ENV['REDIS_URL'] = "redis://localhost:6379/2"
+        expect(Pubsubstub::RedisPubSub.redis_url).to eq("redis://localhost:6379/2")
+
+        Pubsubstub::RedisPubSub.instance_variable_set(:@blocking_redis, nil)
+        ENV['REDIS_URL'] = nil
+        expect(Pubsubstub::RedisPubSub.redis_url).to eq("redis://localhost:6379/0")
+      end
+    end
   end
 
   context "pubsub" do


### PR DESCRIPTION
This adds `Pubsubstub.redis_url` configuration. It would not have helped in this case, but it will remove some of the hacks we have. 

@byroot 
