### PR TITLE
Release dependency on Sinatra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.2.2
+gemfile:
+  - gemfiles/Gemfile.sinatra-1.x
+  - gemfiles/Gemfile.sinatra-2.x
 services:
   - redis-server
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,23 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+namespace :spec do
+  task :all do
+    Dir['gemfiles/*'].reject { |p| p.end_with?('.lock') }.each do |gemfile|
+      command = %(BUNDLE_GEMFILE=#{gemfile} bundle exec rspec)
+      puts command
+      system(command)
+    end
+  end
+end
+
+namespace :gemfiles do
+  task :update do
+    Dir['gemfiles/*'].reject { |p| p.end_with?('.lock') }.each do |gemfile|
+      command = %(BUNDLE_GEMFILE=#{gemfile} bundle update)
+      puts command
+      system(command)
+    end
+  end
+end

--- a/gemfiles/Gemfile.sinatra-1.x
+++ b/gemfiles/Gemfile.sinatra-1.x
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gem 'sinatra', '< 2'
+gem 'redis', '~> 3.0'
+gem "rspec", "3.1.0"
+gem "pry-byebug"
+gem "puma", "~> 3.4"
+gem "thin", "~> 1.6"
+gem "rack-test"
+gem "timecop"
+gem "rake", "~> 10.0"

--- a/gemfiles/Gemfile.sinatra-1.x.lock
+++ b/gemfiles/Gemfile.sinatra-1.x.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (9.0.5)
+    coderay (1.1.1)
+    daemons (1.2.3)
+    diff-lcs (1.2.5)
+    eventmachine (1.2.0.1)
+    method_source (0.8.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    puma (3.5.0)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rake (10.5.0)
+    redis (3.3.1)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    thin (1.7.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    tilt (2.0.5)
+    timecop (0.8.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry-byebug
+  puma (~> 3.4)
+  rack-test
+  rake (~> 10.0)
+  redis (~> 3.0)
+  rspec (= 3.1.0)
+  sinatra (< 2)
+  thin (~> 1.6)
+  timecop
+
+BUNDLED WITH
+   1.12.5

--- a/gemfiles/Gemfile.sinatra-2.x
+++ b/gemfiles/Gemfile.sinatra-2.x
@@ -1,9 +1,7 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in pubsubstub.gemspec
-gemspec
-
 gem 'sinatra', github: 'sinatra/sinatra', ref: 'a5da6fa82c46436f59ae482d07c1752ab908c852'
+gem 'redis', '~> 3.0'
 gem "rspec", "3.1.0"
 gem "pry-byebug"
 gem "puma", "~> 3.4"

--- a/gemfiles/Gemfile.sinatra-2.x.lock
+++ b/gemfiles/Gemfile.sinatra-2.x.lock
@@ -1,0 +1,74 @@
+GIT
+  remote: git://github.com/sinatra/sinatra.git
+  revision: a5da6fa82c46436f59ae482d07c1752ab908c852
+  ref: a5da6fa82c46436f59ae482d07c1752ab908c852
+  specs:
+    sinatra (2.0.0.pre.alpha)
+      mustermann (~> 0.4)
+      rack (~> 2.0)
+      rack-protection (~> 1.5)
+      tilt (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (9.0.5)
+    coderay (1.1.1)
+    daemons (1.2.3)
+    diff-lcs (1.2.5)
+    eventmachine (1.2.0.1)
+    method_source (0.8.2)
+    mustermann (0.4.0)
+      tool (~> 0.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    puma (3.5.0)
+    rack (2.0.1)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rake (10.5.0)
+    redis (3.3.1)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    slop (3.6.0)
+    thin (1.7.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    tilt (2.0.5)
+    timecop (0.8.1)
+    tool (0.2.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry-byebug
+  puma (~> 3.4)
+  rack-test
+  rake (~> 10.0)
+  redis (~> 3.0)
+  rspec (= 3.1.0)
+  sinatra!
+  thin (~> 1.6)
+  timecop
+
+BUNDLED WITH
+   1.12.5

--- a/pubsubstub.gemspec
+++ b/pubsubstub.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sinatra', "~> 1.4"
-  spec.add_dependency 'redis', "~> 3.0"
+  spec.add_dependency 'sinatra', '>= 1.4.7', '< 3'
+  spec.add_dependency 'redis', '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 1.5"
 end


### PR DESCRIPTION
Ref: https://github.com/Shopify/shipit-engine/pull/593

So far Sinatra haven't released a Rack 2.0 compatible version, but it's master branch is: https://github.com/sinatra/sinatra/issues/1135

I tested pubsubstub and it works fine with Sinatra's master. I think it's fair to assume Sinatra 2.x will be compatible with pubsubstub (we use a very small part of the API anyway).

I added test for both versions.

@gmalette good for you? (we'd need to release a `0.1.1` or `0.2.0` as well).
