### PR TITLE
Add Pubsubstub.use_persistent_connections to easilly fallback to polling

### DIFF
--- a/lib/pubsubstub.rb
+++ b/lib/pubsubstub.rb
@@ -21,7 +21,8 @@ module Pubsubstub
 
   class << self
     attr_accessor :heartbeat_frequency, :redis_url, :channels_scrollback_size,
-      :channels_scrollback_ttl, :logger, :reconnect_timeout, :error_handler
+      :channels_scrollback_ttl, :logger, :reconnect_timeout, :error_handler,
+      :use_persistent_connections
 
     def publish(channel_name, *args)
       Channel.new(channel_name).publish(Event.new(*args))
@@ -69,6 +70,7 @@ module Pubsubstub
   self.channels_scrollback_size = 1000
   self.channels_scrollback_ttl = 24 * 60 * 60
   self.reconnect_timeout = 10_000
+  self.use_persistent_connections = true
 
   # Deprecated. Use Pubsubstub.publish instead
   module RedisPubSub

--- a/lib/pubsubstub/stream_action.rb
+++ b/lib/pubsubstub/stream_action.rb
@@ -19,10 +19,10 @@ module Pubsubstub
       request = Rack::Request.new(env)
       channels = (request.params['channels'] || [:default]).map(&Channel.method(:new))
 
-      stream = if event_machine?
-        send_scrollback(channels, last_event_id)
-      else
+      stream = if use_persistent_connections?
         subscribe_connection(channels, last_event_id)
+      else
+        send_scrollback(channels, last_event_id)
       end
       [200, HEADERS, stream]
     end
@@ -38,6 +38,10 @@ module Pubsubstub
           connection << event.to_message
         end
       end
+    end
+
+    def use_persistent_connections?
+      Pubsubstub.use_persistent_connections && !event_machine?
     end
 
     def event_machine?

--- a/spec/channel_spec.rb
+++ b/spec/channel_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Pubsubstub::Channel do
+RSpec.describe Pubsubstub::Channel do
   subject { described_class.new('foobar') }
 
   it "has a name" do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Pubsubstub::Event do
+RSpec.describe Pubsubstub::Event do
   subject {
     Pubsubstub::Event.new("refresh #1500\nnew #1400", id: 12345678, name: "toto", retry_after: 1_000)
   }

--- a/spec/publish_action_spec.rb
+++ b/spec/publish_action_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Pubsubstub::StreamAction do
+RSpec.describe Pubsubstub::StreamAction do
   let(:app) { Pubsubstub::PublishAction.new }
   let(:channel) { Pubsubstub::Channel.new('foo') }
 

--- a/spec/stream_action_spec.rb
+++ b/spec/stream_action_spec.rb
@@ -1,5 +1,23 @@
 require 'spec_helper'
 
+RSpec.shared_examples "short lived connections" do
+  it "immediately returns the scrollback" do
+    Pubsubstub.publish('foo', 'bar', id: 1)
+    Pubsubstub.publish('foo', 'baz', id: 2)
+
+    get '/?channels[]=foo', {}, 'HTTP_LAST_EVENT_ID' => 1
+    expect(last_response.body).to eq("id: 2\ndata: baz\n\n")
+  end
+
+  it "returns and heartbeat if scrollback is empty" do
+    Timecop.freeze('2015-01-01T00:00:00+00:00') do
+      get '/'
+      message = "id: 1420070400000\nevent: heartbeat\nretry: #{Pubsubstub.reconnect_timeout}\ndata: ping\n\n"
+      expect(last_response.body).to eq(message)
+    end
+  end
+end
+
 describe Pubsubstub::StreamAction do
   let(:app) { Pubsubstub::StreamAction.new }
 
@@ -8,21 +26,18 @@ describe Pubsubstub::StreamAction do
       allow(EventMachine).to receive(:reactor_running?).and_return(true)
     end
 
-    it "immediately returns the scrollback" do
-      Pubsubstub.publish('foo', 'bar', id: 1)
-      Pubsubstub.publish('foo', 'baz', id: 2)
+    it_behaves_like "short lived connections"
+  end
 
-      get '/?channels[]=foo', {}, 'HTTP_LAST_EVENT_ID' => 1
-      expect(last_response.body).to eq("id: 2\ndata: baz\n\n")
+  context "with persistent connections disabled" do
+    around :example do |example|
+      previous = Pubsubstub.use_persistent_connections
+      Pubsubstub.use_persistent_connections = false
+      example.run
+      Pubsubstub.use_persistent_connections = previous
     end
 
-    it "returns and heartbeat if scrollback is empty" do
-      Timecop.freeze('2015-01-01T00:00:00+00:00') do
-        get '/'
-        message = "id: 1420070400000\nevent: heartbeat\nretry: #{Pubsubstub.reconnect_timeout}\ndata: ping\n\n"
-        expect(last_response.body).to eq(message)
-      end
-    end
+    it_behaves_like "short lived connections"
   end
 
   it "immediately send a heartbeat event if there is no scrollback" do

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Pubsubstub::Subscriber do
+RSpec.describe Pubsubstub::Subscriber do
   describe "#start" do
     let(:channel) { Pubsubstub::Channel.new('plop') }
     let(:events) { (1..10).map { |i| Pubsubstub::Event.new("refresh ##{i}", id: i) } }

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Pubsubstub::Subscription do
+RSpec.describe Pubsubstub::Subscription do
   let(:event) { Pubsubstub::Event.new('hello') }
   let(:connection) { [] }
   let(:channels) { %w(foo bar).map(&Pubsubstub::Channel.method(:new)) }


### PR DESCRIPTION
Ref: https://github.com/Shopify/shipit-engine/issues/612

Pubsubstub already fallback to a polling strategy if it detect it's in EventMachine, but there is currently no way to force it to do so in other cases.

As seen in https://github.com/Shopify/shipit-engine/issues/612 it can sometimes make sense to want this fallback for other servers. 

This PR adds a global switch for it.

@gmalette for review please.

cc @pollosp this should allow you to use Unicorn without much downsides.
